### PR TITLE
Upgrade @aantron/repromise to reason-promise

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -16,7 +16,7 @@
     }
   ],
   "bs-dependencies": [
-    "reason-react", 
-    "reason-react-native",
-    "@aantron/repromise"]
+    "reason-promise",
+    "reason-react",
+    "reason-react-native"]
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "test": "jest"
   },
   "dependencies": {
-    "@aantron/repromise": "^0.6.1",
     "react": "^16.8.0",
     "react-native": "^0.60.0",
     "react-native-geolocation-service": "^3.1.0",
+    "reason-promise": "^1.0.2",
     "reason-react": "^0.7.0",
     "reason-react-native": "^0.60.0"
   },
@@ -24,7 +24,7 @@
     "@babel/runtime": "^7.3.1",
     "@react-native-community/eslint-config": "^0.0.3",
     "babel-jest": "^24.1.0",
-    "bs-platform": "^5.0.4",
+    "bs-platform": "^7.0.1",
     "jest": "^24.1.0",
     "metro-react-native-babel-preset": "^0.51.1",
     "react-test-renderer": "16.8.1"

--- a/src/App.re
+++ b/src/App.re
@@ -106,22 +106,21 @@ module LocationTracker = {
       } else {
         open Js.Result;
         let p1 = PermissionsAndroid.requestWithRationale(PermissionsAndroid.Permission.accessFineLocation, rationale);
-        let p2 = 
+        let p2 =
           p1
-          |> Repromise.Rejectable.fromJsPromise
-          |> Repromise.Rejectable.map(res => Ok(res))
-          |> Repromise.Rejectable.catch(err => Repromise.resolved(Error(err)));
-      
-        p2 |> Repromise.wait(fun 
+          ->Promise.Js.fromBsPromise
+          ->Promise.Js.toResult;
+
+        p2->Promise.get(fun
           | Ok(v) => {
               Js.log("ok");
-              Js.log(v); 
+              Js.log(v);
               if (v == PermissionsAndroid.Result.granted) {
                 setTrackingLoc(_ => true);
                 ()
-              } else { 
+              } else {
                 setTrackingLoc(_ => false);
-              }; 
+              };
             }
           | Error(e) => {
               Js.log(e);
@@ -140,7 +139,7 @@ module LocationTracker = {
 
           let w = makeWatchPosition(
             { pos => {
-                Js.log("success"); 
+                Js.log("success");
                 Js.log(pos##coords##longitude);
                 Js.log(pos##coords##latitude);
                 ()
@@ -173,14 +172,14 @@ module LocationTracker = {
       [|trackingLoc|],
     );
 
-    let stateString = 
-      if (trackingLoc) 
-      { 
+    let stateString =
+      if (trackingLoc)
+      {
         "Geolocation service IS ACTIVE - touch to deactivate."->React.string;
       } else {
         "Geolocation service is inactive - touch to ACTIVATE."->React.string;
       };
-    
+
     // ...
 
       <TouchableOpacity
@@ -189,7 +188,7 @@ module LocationTracker = {
           {stateString}
         </Text>
       </TouchableOpacity>
-    
+
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,6 +921,11 @@
     eslint-plugin-react-native "3.6.0"
     prettier "1.16.4"
 
+"@react-native-community/geolocation@^1.4.2":
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/@react-native-community/geolocation/-/geolocation-1.4.2.tgz#7228c6d37c2f55017af9c49c2b9ad586d9bcb9f8"
+  integrity sha512-9x9dHDeUXnh2larA4zTT3y/tXPmRnysh5o9fsNbGcnUKPj1BUCIHnGGPxEIDnwP1DNIMP2DN9DmuMHImtTbX6A==
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1468,10 +1473,10 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
-bs-platform@^5.0.4:
-  version "5.0.6"
-  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-5.0.6.tgz#88c13041fb020479800de3d82c680bf971091425"
-  integrity sha512-6Boa2VEcWJp2WJr38L7bp3J929nYha7gDarjxb070jWzgfPJ/WbzjipmSfnu2eqqk1MfjEIpBipbPz6n1NISwA==
+bs-platform@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/bs-platform/-/bs-platform-7.0.1.tgz#1d7b0ef6088b998dceee5db74a7cd8f01c20a3bd"
+  integrity sha512-UjStdtHhbtC/l6vKJ1XRDqrPk7rFf5PLYHtRX3akDXEYVnTbN36z0g4DEr5mU8S0N945e33HYts9x+i7hKKpZQ==
 
 bser@^2.0.0:
   version "2.1.0"
@@ -4929,6 +4934,13 @@ react-is@^16.8.1, react-is@^16.8.4:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"
   integrity sha512-INBT1QEgtcCCgvccr5/86CfD71fw9EPmDxgiJX4I2Ddr6ZsV6iFXsuby+qWJPtmNuMY0zByTsG4468P7nHuNWA==
 
+react-native-geolocation-service@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-native-geolocation-service/-/react-native-geolocation-service-3.1.0.tgz#62e112374f1cd284ea00ced0ef6826af820f50e2"
+  integrity sha512-h0RwffuTt8ElpWQBJofao5+n1DT+GJfzSx5Pw+VYgQO+PmyYwhSthMSz+6F+9ZbgVHANm6w6HmTPRFYEsbjkYA==
+  dependencies:
+    "@react-native-community/geolocation" "^1.4.2"
+
 react-native@^0.60.0:
   version "0.60.6"
   resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.60.6.tgz#8a13dece1c3f6e01db0833db14d2b01b2d8ccba5"
@@ -5051,6 +5063,11 @@ realpath-native@^1.1.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+reason-promise@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/reason-promise/-/reason-promise-1.0.2.tgz#22b9bb4097ce511190182b948aef11427d5b8b86"
+  integrity sha512-j8DWV+71wNEKQmyW6zBOowIZq1Qec5CDWyLI37BvgOmAZgRFGFQ1MaJnbhqDe3JsYmaGyqdNMmpCJLl9EDbDAg==
 
 reason-react-native@^0.60.0:
   version "0.60.0"


### PR DESCRIPTION
Repromise became [**reason-promise**](https://github.com/aantron/promise) in 1.0.0. The API was renamed (e.g., `Repromise.wait` is now `Promise.get`), rearranged to prefer `->` instead of `|>`, and helpers were added for `Result` and `Option`, as well as some miscellaneous ones. The bundle size was reduced to 1K. See the [changelog](https://github.com/aantron/promise/releases/tag/1.0.0) here; there are also two subsequent bugfix releases.

My editor also trimmed some trailing whitespace in the diff. I'll be happy to remove that part change, if you prefer.